### PR TITLE
feat: Add Docker Compose setup for frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Proyecto Gamificación
+
+Este es un proyecto de gamificación que consta de un frontend desarrollado con Next.js y un backend desarrollado con NestJS.
+
+## Estructura del Proyecto
+
+- `apps/frontend`: Contiene la aplicación frontend de Next.js.
+- `apps/backend`: Contiene la aplicación backend de NestJS.
+
+## Configuración y Ejecución
+
+Para configurar y ejecutar el proyecto, por favor, consulta los `README.md` individuales en las carpetas `apps/frontend` y `apps/backend`.

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+EXPOSE 3001
+CMD ["pnpm", "start"]

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+EXPOSE 3000
+CMD ["pnpm", "start"]

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: ./apps/frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./apps/frontend:/app
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./apps/backend
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./apps/backend:/app
+    environment:
+      NODE_ENV: development
+
+  # globalping-mcp-server:
+  #   image: globalping/mcp-server:latest
+  #   ports:
+  #     - "8080:8080"
+  #   environment:
+  #     - GLOBALPING_API_KEY=your_api_key # Replace with your GlobalPing API key
+  #   networks:
+  #     - default
+
+networks:
+  default:
+    driver: bridge


### PR DESCRIPTION
This PR introduces Docker Compose configuration for the frontend (Next.js) and backend (NestJS) applications. It includes:

- `infra/docker-compose.yml`: Defines services for frontend and backend, with a placeholder for GlobalPing MCP server.
- `apps/frontend/Dockerfile`: Dockerfile for building the Next.js frontend application.
- `apps/backend/Dockerfile`: Dockerfile for building the NestJS backend application.

These changes enable containerized development and deployment for the project.