### PR TITLE
fix(T-INFRA): Corregir build de Docker para el backend

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,8 +1,26 @@
-FROM node:20-alpine
+FROM node:20-slim
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+
+# Install pnpm globally
+RUN npm install -g pnpm
+
+# Copy files needed for installation
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/backend/package.json ./apps/backend/
+COPY apps/frontend/package.json ./apps/frontend/
+COPY packages/config/package.json ./packages/config/
+
+# Install all monorepo dependencies
 RUN pnpm install --frozen-lockfile
+
+# Copy the rest of the source code
 COPY . .
-RUN pnpm run build
+
+# Set working directory to backend application
+WORKDIR /app/apps/backend
+
+# Build the backend application
+RUN pnpm --filter backend build
+
 EXPOSE 3001
-CMD ["pnpm", "start"]
+CMD ["pnpm", "run", "start:prod"]

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  outputFileTracingRoot: require("path").resolve(__dirname, "../../.."),
+  outputFileTracingRoot: require("path").resolve(__dirname, "../.."),
 };
 
 export default nextConfig;

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   mongodb:
     image: mongo:latest
@@ -13,8 +11,8 @@ services:
 
   backend:
     build:
-      context: ./apps/backend
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: ./apps/backend/Dockerfile
     container_name: backend
     ports:
       - "3001:3001"


### PR DESCRIPTION
Se soluciona el proceso de construcción de Docker para el servicio de backend que fallaba al ejecutarse en un monorepo con pnpm.

Los cambios principales son:
- Se ajusta el Dockerfile para copiar correctamente los archivos de workspace (pnpm-workspace.yaml y los package.json de cada app/paquete) antes de ejecutar `pnpm install`.
- Se cambia la imagen base de node:20-alpine a node:20-slim para mejorar la estabilidad.
- Se corrige el build context en docker-compose.yml para apuntar a la raíz del monorepo.
- Se actualiza el CMD en el Dockerfile para usar el script de producción (start:prod).