### PR TITLE
feat(T-CI): Agregar verificación de tipos de TypeScript al pipeline de CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Run TypeScript type check
+        run: pnpm --filter backend exec tsc --noEmit && pnpm --filter frontend exec tsc --noEmit
+
       - name: Run linter
         run: pnpm lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ pnpm-debug.log*
 # macOS
 .DS_Store
 .vercel
+apps/backend/dist/


### PR DESCRIPTION
Se agrega un paso al pipeline de CI para verificar los tipos de TypeScript en las aplicaciones de backend y frontend. Esto asegura que cualquier cambio propuesto sea verificado por errores de tipo antes de ser fusionado. También se actualiza el .gitignore para ignorar la carpeta dist del backend.